### PR TITLE
tiniMCE - relative url disable

### DIFF
--- a/plugin/tinymce/tinymce.php
+++ b/plugin/tinymce/tinymce.php
@@ -13,6 +13,7 @@ function tinymceAdminHead(){
   <script>
   tinymce.init({
     selector: 'textarea.editor',
+    relative_urls : false,
     plugins: [
       'advlist autolink link image lists charmap print preview hr anchor pagebreak spellchecker',
       'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',


### PR DESCRIPTION
tiniMCE est configuré par defaut pour des url "relatives" ce qui génère des url invalides après enregistrement des pages.