### PR TITLE
remove php closing tag on php only files

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -58,4 +58,3 @@ elseif($core->detectAdminMode() == 'plugin'){
 	include($runPlugin->getAdminFile());
 	if(!is_array($runPlugin->getAdminTemplate())) include($runPlugin->getAdminTemplate());
 }
-?>

--- a/common/administrator.class.php
+++ b/common/administrator.class.php
@@ -114,4 +114,3 @@ Lien de confirmation : ".$core->getConfigVal('siteUrl')."/admin/index.php?action
     }
 
 }
-?>

--- a/common/common.php
+++ b/common/common.php
@@ -36,4 +36,3 @@ foreach($pluginsManager->getPlugins() as $plugin){
 }
 ## $runPLugin représente le plugin en cours d'execution et s'utilise avec la classe plugin & pluginsManager
 $runPlugin = $pluginsManager->getPlugin($core->getPluginToCall());
-?>

--- a/common/config.php
+++ b/common/config.php
@@ -23,4 +23,3 @@ define('ADMIN_PATH', ROOT.'admin/');
 define('NORMALIZE', 'https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css');
 define('JQUERY', 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js');
 if(file_exists(DATA.'key.php')) include(DATA.'key.php');
-?>

--- a/common/core.class.php
+++ b/common/core.class.php
@@ -198,4 +198,3 @@ class core{
         @file_put_contents(ROOT.'.htaccess', $content);
     }
 }
-?>

--- a/common/plugin.class.php
+++ b/common/plugin.class.php
@@ -248,4 +248,3 @@ class plugin{
 		return false;
 	}
 }
-?>

--- a/common/pluginsManager.class.php
+++ b/common/pluginsManager.class.php
@@ -124,4 +124,3 @@ class pluginsManager{
 		return $plugin;
 	}
 }
-?>

--- a/common/show.class.php
+++ b/common/show.class.php
@@ -201,4 +201,3 @@ class show{
 		if(file_exists($icon)) echo $icon;
 	}
 }
-?>

--- a/common/util.class.php
+++ b/common/util.class.php
@@ -126,4 +126,3 @@ class util{
     	return $data;
     }
 }
-?>

--- a/index.php
+++ b/index.php
@@ -19,4 +19,3 @@ elseif($runPlugin->getPublicFile()){
 	include($runPlugin->getPublicFile());
 	include($runPlugin->getPublicTemplate());
 }
-?>

--- a/plugin/antispam/antispam.php
+++ b/plugin/antispam/antispam.php
@@ -32,4 +32,3 @@ class antispam{
         return false;
     }
 }
-?>

--- a/plugin/blog/admin.php
+++ b/plugin/blog/admin.php
@@ -114,4 +114,3 @@ switch($action){
 	default:
 		$mode = 'list';
 }
-?>

--- a/plugin/blog/blog.php
+++ b/plugin/blog/blog.php
@@ -345,4 +345,3 @@ class newsComment{
 		return $this->content;
 	}
 }
-?>

--- a/plugin/blog/public.php
+++ b/plugin/blog/public.php
@@ -92,4 +92,3 @@ switch($action){
 	default:
 		$core->error404();
 }
-?>

--- a/plugin/configmanager/admin.php
+++ b/plugin/configmanager/admin.php
@@ -45,4 +45,3 @@ switch($action){
 		}
 		break;
 }
-?>

--- a/plugin/configmanager/configmanager.php
+++ b/plugin/configmanager/configmanager.php
@@ -8,4 +8,3 @@ function configmanagerInstall(){
 
 ## Hooks
 ## Code relatif au plugin
-?>

--- a/plugin/contact/admin.php
+++ b/plugin/contact/admin.php
@@ -24,4 +24,3 @@ switch($action){
         $emails = implode("\n", util::readJsonFile(DATA_PLUGIN.'contact/emails.json'));
         break;
 }
-?>

--- a/plugin/contact/contact.php
+++ b/plugin/contact/contact.php
@@ -37,4 +37,3 @@ function contactSend(){
 	if(util::isEmail($runPlugin->getConfigVal('copy'))) util::sendEmail($from, $reply, $runPlugin->getConfigVal('copy'), $subject, $msg);
 	return util::sendEmail($from, $reply, $to, $subject, $msg);
 }
-?>

--- a/plugin/contact/public.php
+++ b/plugin/contact/public.php
@@ -29,4 +29,3 @@ $acceptation = (trim($runPlugin->getConfigVal('acceptation')) != '') ? true : fa
 $runPlugin->setMainTitle($runPlugin->getConfigVal('label'));
 $runPlugin->setTitleTag($runPlugin->getConfigVal('label'));
 $antispamField = ($antispam) ? $antispam->show() : '';
-?>

--- a/plugin/contact/template/public.php
+++ b/plugin/contact/template/public.php
@@ -37,4 +37,3 @@ echo $runPlugin->getConfigVal('content1');
 <?php
 echo $runPlugin->getConfigVal('content2');
 include_once(ROOT.'theme/'.$core->getConfigVal('theme').'/footer.php');
-?>

--- a/plugin/galerie/admin.php
+++ b/plugin/galerie/admin.php
@@ -67,4 +67,3 @@ switch($action){
 	default:
 		$mode = 'list';
 }
-?>

--- a/plugin/galerie/galerie.php
+++ b/plugin/galerie/galerie.php
@@ -334,4 +334,3 @@ function galerieResize($Wmax, $Hmax, $rep_Dst, $img_Dst, $rep_Src, $img_Src){
  if ($condition == 1 && file_exists($rep_Dst.$img_Dst)) { return true; }
  else { return false; }
 }
-?>

--- a/plugin/galerie/public.php
+++ b/plugin/galerie/public.php
@@ -8,4 +8,3 @@ if($runPlugin->getIsDefaultPlugin()){
     $runPlugin->setMetaDescriptionTag($core->getConfigVal('siteDescription'));
 }
 $runPlugin->setMainTitle($runPlugin->getConfigVal('label'));
-?>

--- a/plugin/page/admin.php
+++ b/plugin/page/admin.php
@@ -107,4 +107,3 @@ switch($action){
 		if(!$page->createHomepage()) $msg = "Aucune page d'accueil définie";
 		$mode = 'list';
 }
-?>

--- a/plugin/page/page.php
+++ b/plugin/page/page.php
@@ -446,4 +446,3 @@ class pageItem{
 		else return 'plugin';
 	}
 }
-?>

--- a/plugin/page/public.php
+++ b/plugin/page/public.php
@@ -34,4 +34,3 @@ switch($action){
             $runPlugin->setMainTitle('Accès restreint');
         }
 }
-?>

--- a/plugin/page/template/public.php
+++ b/plugin/page/template/public.php
@@ -22,4 +22,3 @@ else{ ?>
 </form>
 <?php }
 include_once(THEMES.$core->getConfigVal('theme').'/footer.php');
-?>

--- a/plugin/pluginsmanager/admin.php
+++ b/plugin/pluginsmanager/admin.php
@@ -49,4 +49,3 @@ switch($action){
 		die();
 		break;
 }
-?>

--- a/plugin/pluginsmanager/pluginsmanager.php
+++ b/plugin/pluginsmanager/pluginsmanager.php
@@ -8,4 +8,3 @@ function pluginsmanagerInstall(){
 
 ## Hooks
 ## Code relatif au plugin
-?>

--- a/plugin/seo/admin.php
+++ b/plugin/seo/admin.php
@@ -27,4 +27,3 @@ switch($action){
 		break;
 	default:
 }
-?>

--- a/plugin/seo/seo.php
+++ b/plugin/seo/seo.php
@@ -45,4 +45,3 @@ function seoEndFrontBody(){
         echo '</div>';
     }
 }
-?>

--- a/plugin/tinymce/tinymce.php
+++ b/plugin/tinymce/tinymce.php
@@ -25,4 +25,3 @@ function tinymceAdminHead(){
 }
 
 ## Code relatif au plugin
-?>

--- a/theme/default/functions.php
+++ b/theme/default/functions.php
@@ -1,3 +1,2 @@
 <?php
 ## Code php du thème...
-?>


### PR DESCRIPTION
Deletion of closing tags on PHP only files.

They are error prone and useless.